### PR TITLE
Upgrade python-json-logger to 4.1.0 (no deprecation warning)

### DIFF
--- a/logging.conf
+++ b/logging.conf
@@ -36,4 +36,4 @@ datefmt=
 
 [formatter_jsonFormatter]
 format = %(asctime)s %(levelname) %(threadName)s %(name)s %(lineno)d %(message)s %(funcName)s
-class = pythonjsonlogger.jsonlogger.JsonFormatter
+class = pythonjsonlogger.json.JsonFormatter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests~=2.32.5
-python-json-logger~=3.2.1
+python-json-logger~=4.1.0
 psycopg2-binary~=2.9.12
 sqlalchemy~=2.0.46
 git+https://github.com/OCHA-DAP/hdx-redis-lib.git@0.3.2


### PR DESCRIPTION
## What

Supersedes dependabot PR #44 (`python-json-logger` 3.2.1 → 4.0.0), which upgraded the dependency but left the code on the deprecated module path.

- Bumps `python-json-logger` from `~=3.2.1` to `~=4.1.0` (latest).
- Updates `logging.conf` to use `pythonjsonlogger.json.JsonFormatter` instead of the deprecated `pythonjsonlogger.jsonlogger.JsonFormatter`.

## Why

In python-json-logger 4.x, `pythonjsonlogger.jsonlogger` is a compatibility stub that emits a `DeprecationWarning` on import and is slated for removal. Just bumping the version (as #44 did) would keep working but spam deprecation warnings. This PR moves to the supported `pythonjsonlogger.json` path so no warning is emitted.

## Testing

- Loaded `logging.conf` with `python-json-logger==4.1.0` and `DeprecationWarning` promoted to an error — config loads and logs cleanly, JSON output unchanged (all expected fields present).
- Confirmed the old `pythonjsonlogger.jsonlogger` path still emits the deprecation warning under 4.1.0, while the new path does not.
- Full test suite passes (24 passed) against Redis + Postgres services matching CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)